### PR TITLE
[droid;packagaing] Remove non-relevant comment

### DIFF
--- a/tools/android/packaging/xbmc/AndroidManifest.xml.in
+++ b/tools/android/packaging/xbmc/AndroidManifest.xml.in
@@ -5,7 +5,6 @@
     android:versionCode="@APP_VERSION_CODE@"
     android:versionName="@APP_VERSION@" >
 
-    <!-- This is the platform API where NativeActivity was introduced. -->
     <uses-sdk android:minSdkVersion="17" android:targetSdkVersion="21" />
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />


### PR DESCRIPTION
* https://github.com/xbmc/xbmc/commit/e2ee1f12392ab9c03e4b908dac8ca627230e2fc7 bumped the API minimum to 17; NativeActivity was introduced before API 17.